### PR TITLE
Update 0.15.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "streamlit-folium" %}
-{% set version = "0.11.0" %}
+{% set version = "0.15.0" %}
 
 
 package:
@@ -8,21 +8,23 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/streamlit_folium-{{ version }}.tar.gz
-  sha256: ef18586ff471f6615b5aceb72affd27babf25e077bc29dff9e2a7bf98f666c45
+  sha256: 2908c98487e914493c730fb71c70fa6dfb1e482a404b7c10b7511579358701c1
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: True  # [py<38]
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - setuptools
+    - wheel
   run:
-    - folium >=0.11
-    - streamlit >=1.2
-    - python >=3.7
+    - python
+    - folium >=0.13
+    - streamlit >=1.13
     - branca
     - jinja2
 
@@ -38,7 +40,12 @@ about:
   home: https://github.com/randyzwitch/streamlit-folium
   summary: Render Folium objects in Streamlit
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  description: |
+    streamlit-folium integrates two great open-source projects in the Python ecosystem: Streamlit and Folium!
+  doc_url: https://github.com/randyzwitch/streamlit-folium/blob/master/README.md
+  dev_url: https://github.com/randyzwitch/streamlit-folium
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<38]
+  skip: True  # [py<38 or s390x]
 
 requirements:
   host:


### PR DESCRIPTION
# ❄️☆Streanlit-folium 0.15.0 Update ☆❄️
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-3086)
[Upstream](https://github.com/randyzwitch/streamlit-folium)
[Dependencies ](https://github.com/randyzwitch/streamlit-folium/blob/master/setup.py)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Skip for `s390x`